### PR TITLE
Increase the timeout for putRequest to 60s from the current 5 seconds.

### DIFF
--- a/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobStore.java
+++ b/oci-repository-plugin/src/main/java/org/opensearch/repositories/oci/OciObjectStorageBlobStore.java
@@ -705,7 +705,7 @@ class OciObjectStorageBlobStore implements BlobStore {
                                     public void onError(PutObjectRequest putObjectRequest, Throwable error) {
                                         log.error("error put object: {}, bucket: {}, namespace: {}", objectName, bucketName, namespace, error);
                                     }
-                                }).get(5, TimeUnit.SECONDS);
+                                }).get(60, TimeUnit.SECONDS);
                                 final Instant end = Instant.now();
                                 log.info(
                                         "Finished pushing object '/n/{}/b/{}/o/{}' in {} millis",


### PR DESCRIPTION
Increasing the timeout for putRequest to 60s from the current 5 seconds. Snapshot requests are failing in the OIC Dev environment due to the short timeout period for put requests.